### PR TITLE
change endpoint name public-key to stripe-key for ruby server

### DIFF
--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -25,19 +25,11 @@ get '/' do
   send_file File.join(settings.public_folder, 'index.html')
 end
 
-get '/public-key' do
+get '/stripe-key' do
   content_type 'application/json'
 
   {
     'publicKey': ENV['STRIPE_PUBLISHABLE_KEY']
-  }.to_json
-end
-
-get '/stripe-key' do
-  content_type 'application/json'
-  # Send publishable key to client
-  {
-    publicKey: ENV['STRIPE_PUBLISHABLE_KEY']
   }.to_json
 end
 

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -33,6 +33,14 @@ get '/public-key' do
   }.to_json
 end
 
+get '/stripe-key' do
+  content_type 'application/json'
+  # Send publishable key to client
+  {
+    publicKey: ENV['STRIPE_PUBLISHABLE_KEY']
+  }.to_json
+end
+
 post '/create-setup-intent' do
   content_type 'application/json'
 


### PR DESCRIPTION
the stripe-key was missing on the server endpoints. What made it impossible to run the sample