### PR TITLE
fix: styling issue causing CC number to overlap on mobile

### DIFF
--- a/client/css/global.css
+++ b/client/css/global.css
@@ -19,7 +19,7 @@
 }
 body {
   font-family: var(--body-font-family);
-  font-size: 16px;
+  font-size: 15px;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -231,6 +231,7 @@ pre {
       0px 2px 5px 0px rgba(50, 50, 93, 0.1),
       0px 1px 1.5px 0px rgba(0, 0, 0, 0.07);
     border-radius: 6px;
+    padding: 20px 20px 75px 20px;
   }
 }
 

--- a/client/script.js
+++ b/client/script.js
@@ -5,7 +5,7 @@ var stripeElements = function(publicKey, setupIntent) {
   // Element styles
   var style = {
     base: {
-      fontSize: "16px",
+      fontSize: "15px",
       color: "#32325d",
       fontFamily:
         "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif",


### PR DESCRIPTION
This PR makes a small style change to improve the experience on mobile. 

The issue was mainly caused by having too much padding on the CC field on smaller screen.

(fixes #5)